### PR TITLE
Add Clojure 1.6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ involved options to Clojure and the the JVM.
 
 ## Supported Clojure versions
 
-HipHip is currently supported on Clojure 1.5.x.
+HipHip is currently supported on Clojure 1.5.x and 1.6.x.
 
 ## Contributors
 

--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,9 @@
   :profiles {:dev {:plugins [[lein-marginalia "0.7.1"]]
                    :dependencies [[org.clojure/clojure "1.5.1"]
                                   [criterium "0.4.1"]
-                                  [org.clojure/test.generative "0.4.0"]]}}
+                                  [org.clojure/test.generative "0.4.0"]]}
+             :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}}
+  :aliases {"all" ["with-profile" "dev:dev,1.6"]}
   :test-selectors {:fast #(not (or (:bench %) (:gen-test %)))
                    :gen-test :gen-test
                    :bench :bench}


### PR DESCRIPTION
Tests all pass on 1.6, but have not analyzed the full benchmark suite yet.
