### PR TITLE
save and restore *uncheck-math* and *warn-on-reflection* in type_impl

### DIFF
--- a/src/hiphip/type_impl.clj
+++ b/src/hiphip/type_impl.clj
@@ -1,6 +1,8 @@
 ;; As a hack to avoid writing macro-macros, this file defines the
 ;; per-type macros, and is loaded in each type's namespace.
 
+(def ^:private saved-warn-on-reflection *warn-on-reflection*)
+(def ^:private saved-unchecked-math *unchecked-math*)
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* true)
 (require '[hiphip.impl.core :as impl] '[hiphip.array :as array])
@@ -296,4 +298,5 @@
     (aselect-indices! xs k)
     (asort-indices! xs 0 k)))
 
-(set! *warn-on-reflection* false)
+(set! *warn-on-reflection* saved-warn-on-reflection)
+(set! *unchecked-math* saved-unchecked-math)


### PR DESCRIPTION
This is a minor change so the hiphip library won't interference user's option settings.